### PR TITLE
Добавил возможность менять логику установки значения в Name claim.

### DIFF
--- a/sources/Duke.Owin.VkontakteMiddleware.csproj
+++ b/sources/Duke.Owin.VkontakteMiddleware.csproj
@@ -32,16 +32,16 @@
   <ItemGroup>
     <Reference Include="Microsoft.Owin, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\EmailMvc2Test\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Security">
-      <HintPath>..\..\EmailMvc2Test\packages\Microsoft.Owin.Security.2.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Security.2.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
-      <HintPath>..\..\EmailMvc2Test\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -65,6 +65,7 @@
     <Compile Include="VkAuthenticationHandler.cs" />
     <Compile Include="VkAuthenticationMiddleware.cs" />
     <Compile Include="VkAuthenticationOptions.cs" />
+    <Compile Include="VkAuthenticationPreferedName.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/sources/VkAuthenticationHandler.cs
+++ b/sources/VkAuthenticationHandler.cs
@@ -216,7 +216,7 @@ namespace Duke.Owin.VkontakteMiddleware
                 XmlDocument UserInfoResponseXml = new XmlDocument();
                 UserInfoResponseXml.LoadXml(text);
 
-                var context = new VkAuthenticatedContext(Context, UserInfoResponseXml, accessToken, expires);
+                var context = new VkAuthenticatedContext(Context, UserInfoResponseXml, accessToken, expires, Options.PreferedNameClaim);
                 context.Identity = new ClaimsIdentity(
                     Options.AuthenticationType,
                     ClaimsIdentity.DefaultNameClaimType,

--- a/sources/VkAuthenticationOptions.cs
+++ b/sources/VkAuthenticationOptions.cs
@@ -29,6 +29,7 @@ namespace Duke.Owin.VkontakteMiddleware
             Scope = "";
             Version = "5.21";
             BackchannelTimeout = TimeSpan.FromSeconds(60);
+            PreferedNameClaim = VkAuthenticationPreferedName.ScreenName;
         }
 
         /// <summary>
@@ -113,5 +114,10 @@ namespace Duke.Owin.VkontakteMiddleware
         /// Get or set vk.com api version.
         /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// Get or set prefered value for Name claim.
+        /// </summary>
+        public VkAuthenticationPreferedName PreferedNameClaim { get; set; }
     }
 }

--- a/sources/packages.config
+++ b/sources/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security" version="2.1.0" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
По умолчанию в ClaimsIdentity.DefaultNameClaimType записывалось значения поля screen_name, а полное имя записывалось в urn:vkontakte:name. 
Добавил возможность поменять логику заполнения ClaimsIdentity.DefaultNameClaimType. Теперь в опциях можно установить с какого свойства должно устанавливаться значение в поле ClaimsIdentity.DefaultNameClaimType.

Например:
app.UseVkontakteAuthentication(new VkAuthenticationOptions()
            {
                AppId = "123123123",
                AppSecret = "123123123",
                Scope = "email",
                PreferedNameClaim = VkAuthenticationPreferedName.FullName
            });

Так же пофиксал ссылки на либы, некоторые из них ссылались на тестовый проект (EmailMvc2Test).
